### PR TITLE
External Link Targets

### DIFF
--- a/src/SharpDoc/Styles/Standard/html/LinkResolver.cshtml
+++ b/src/SharpDoc/Styles/Standard/html/LinkResolver.cshtml
@@ -33,21 +33,22 @@
         switch (link.Type) {
             case LinkType.None:
                 return Escape(link.Name);
-                break;
             case LinkType.Self:
                 return string.Format("<strong>{0}</strong>", Escape(link.Name));
-                break;
             case LinkType.Local:
                 url = string.Format("{0}{1}{2}", Param.RootLink, link.LocalReference.PageId, Param.FileExt);
                 break;
             case LinkType.External:
-                url = link.Location;
-                break;
+                return string.Format("<a target=\"{0}\" href=\"{1}\" {2}>{3}</a>", 
+                    Param.ExternalLinkTarget ?? "_blank",
+                    link.Location, 
+                    link.Attributes ?? "", 
+                    Escape(link.Name));
         }
         if (url == null)
             return Escape(link.Name);
 
-        return string.Format("<a target='mainFrame' onclick='hightLightTopic(\"{3}\");' href=\"{0}\" {1}>{2}</a>", url, link.Attributes ?? "", Escape(link.Name), link.PageId);
+        return string.Format("<a target=\"mainFrame\" onclick=\"hightLightTopic(\"{3}\");\" href=\"{0}\" {1}>{2}</a>", url, link.Attributes ?? "", Escape(link.Name), link.PageId);
     }
 }
 

--- a/src/SharpDoc/Styles/Standard/style.xml
+++ b/src/SharpDoc/Styles/Standard/style.xml
@@ -30,6 +30,9 @@
   <!-- Description for this style -->
   <description>Default style</description>
 
+  <!-- Defines the anchor target for external links. -->
+  <param name="ExternalLinkTarget">_blank</param>
+  
   <param name="RootLink"></param>
   <param name="FileExt">.htm</param>
 


### PR DESCRIPTION
Added support for setting the target for external links.  By default if unset it will use `_blank`.  This can be changed from the config like so:

```
<param name="ExternalLinkTarget">TheTargetName</param>
```

This fixes #1.
