### PR TITLE
TypeBody/MemberBody Formatting Fix

### DIFF
--- a/src/SharpDoc/Styles/Standard/html/MemberBody.cshtml
+++ b/src/SharpDoc/Styles/Standard/html/MemberBody.cshtml
@@ -43,8 +43,8 @@
 
 <br/>
 <div class="origin">
-<strong>Assembly: </strong>@Model.Assembly.FullName (@Model.Assembly.FileName @Model.Assembly.Version)<br />
 <strong>Namespace: </strong>@Raw(ToUrl(Model.Namespace))<br />
+<strong>Assembly: </strong>@Model.Assembly.FullName (@Model.Assembly.FileName @Model.Assembly.Version)<br />
       
 @Helpers.TypeBodyMembersHeader.Dump(self)
 </div>

--- a/src/SharpDoc/Styles/Standard/html/TypeBody.cshtml
+++ b/src/SharpDoc/Styles/Standard/html/TypeBody.cshtml
@@ -88,8 +88,8 @@
 }
 <br/>
 <div class="origin">
-<strong>Assembly: </strong>@Model.Assembly.FullName (@Model.Assembly.FileName @Model.Assembly.Version)<br />
 <strong>Namespace: </strong>@Raw(ToUrl(Model.Namespace))<br />
+<strong>Assembly: </strong>@Model.Assembly.FullName (@Model.Assembly.FileName @Model.Assembly.Version)<br />
       
 @Helpers.TypeBodyMembersHeader.Dump(self)
 </div>


### PR DESCRIPTION
I noticed some small, but unnecessary formatting differences between TypeBody and MemberBody.  This makes the tops of these pages format identically.
- Made the assembly first across both.
- Removed extra `<p>` around summary.
- Added missing `<br>` between description and assembly name.
