### PR TITLE
Paramref Support

### DIFF
--- a/src/SharpDoc/Styles/Standard/html/TagResolver.cshtml
+++ b/src/SharpDoc/Styles/Standard/html/TagResolver.cshtml
@@ -48,6 +48,12 @@
         return ToUrl(id);
     }
 
+    public string ReplaceParamref(Match match)
+    {
+        string id = match.Groups[1].Value;
+        return @"<span class='sdoc-parameter'>" + id + "</span>";
+    }
+
     public string ReplaceWebdoc(Match match)
     {
         string xmlCode = match.ToString();
@@ -231,6 +237,7 @@
     
     Model.RegisterTagResolver(@"<see\s+cref=""(.*?)""\s*/>", ReplaceSee);
     Model.RegisterTagResolver(@"<see\s+cref=""(.*?)""\s*>(.*?)</see>", ReplaceSee);
+    Model.RegisterTagResolver(@"<paramref\s+name=""(.*?)""\s*/>", ReplaceParamref);
     Model.RegisterTagResolver(@"<webdoc(.*?)>(.*?)</webdoc>", ReplaceWebdoc);
     Model.RegisterTagResolver(@"<codesection(.*?)>([\w\W]*?)</codesection>", ReplaceCodeSection);
     //Model.RegisterTagResolver(@"<code(.*?)>([\w\W]*?)</code>", ReplaceCode);


### PR DESCRIPTION
This PR adds support for `<paramref>` references.

This could possibly be a little better if we added a link to jump down to the parameter description, but I figured this was a good starting point.

Fixes #12.
