### PR TITLE
Fixed Links To Out Types

### DIFF
--- a/src/SharpDoc/DocIdHelper.cs
+++ b/src/SharpDoc/DocIdHelper.cs
@@ -290,6 +290,9 @@ namespace SharpDoc
                 if (thisTypeRef.Name.Contains("`") && thisGenericTypeDef != null)
                     strTempShortTypeName = thisTypeRef.Name.Remove(thisTypeRef.Name.IndexOf("`"));
 
+                // remove any trailing reference syntax.
+                strTempShortTypeName = strTempShortTypeName.TrimEnd('&', '%');
+
                 // class, interface, structure or delegate
                 if (currentPathStack.Count == 0)
                     strTempTypeName = "T:" + strNamespace + strTempShortTypeName;


### PR DESCRIPTION
This fixes the generation of a bad doc ids for `out` or `ref` types in `GetXmlDocPathRecursive`.  Fixes #10.
