### PR TITLE
Fixed bug when parsing the page GET attribute

### DIFF
--- a/src/SharpDoc/Styles/Standard/js/sharpdoc.js
+++ b/src/SharpDoc/Styles/Standard/js/sharpdoc.js
@@ -50,12 +50,11 @@ function loadContent(rootTopic, extension) {
 
     if(data != null && data !="")
     {
-        var pattern = /page=(\w+)/;
-        var page = pattern.exec(data);
-        if(page != null)
+        var page = $get("page", data);
+        if(page != "")
         {
-            url = page[1] + extension;
-            topicToHighlight = page[1];
+            url = page + extension;
+            topicToHighlight = page;
         }
     }
     


### PR DESCRIPTION
This is caused when a page-id has characters outside of `\w`. I ran into this bug when trying to add release notes for each version. I store them in a Release Notes folder and name the pages `0.9.2.md`.

So when you have a page: "index.htm?page=v0.9.2", the existing code will try to load `v0.htm` instead of `v0.9.2.htm`

This fixes it by using the `$get` function that's included in the same file.